### PR TITLE
Add name to alignment settings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -267,6 +267,7 @@ export default class Quote {
 
     return this.settings.map(item => ({
       icon: item.icon,
+      name: item.name,
       label: this.api.i18n.t(`Align ${capitalize(item.name)}`),
       onActivate: () => this._toggleTune(item.name),
       isActive: this.data.alignment === item.name,


### PR DESCRIPTION
This way it has a `data-item-name` on the `.ce-popover-item` to identify the name of the setting, which follows the structure of the default settings of editor.js (like Move up, Delete, Move down).