### PR TITLE
fix(dependencies): breacking dependencies fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   },
   "dependencies": {
     "@codexteam/icons": "^0.3.2",
-    "@editorjs/dom": "^0.0.1"
+    "@editorjs/dom": "^0.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/quote",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "keywords": [
     "codex editor",
     "quote",
@@ -41,6 +41,6 @@
   },
   "dependencies": {
     "@codexteam/icons": "^0.3.2",
-    "@editorjs/dom": "^0.0.6"
+    "@editorjs/dom": "^0.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,22 +33,22 @@
   resolved "https://registry.yarnpkg.com/@codexteam/icons/-/icons-0.3.2.tgz#b7aed0ba7b344e07953101f5476cded570d4f150"
   integrity sha512-P1ep2fHoy0tv4wx85eic+uee5plDnZQ1Qa6gDfv7eHPkCXorMtVqJhzMb75o1izogh6G7380PqmFDXV3bW3Pig==
 
-"@editorjs/dom@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@editorjs/dom/-/dom-0.0.6.tgz#b35a6b4204305f3b1bc3eb7b4c4dec21a4070e3d"
-  integrity sha512-bPwkRV2O7mTB7XoGpf0/anSAOENbwXu2EcOT1M3/lvM9XJ7YfvOgyeSmEZRqUyw5RYBr94yc2fQw++vHMINeqA==
+"@editorjs/dom@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@editorjs/dom/-/dom-0.0.5.tgz#768db5aa3c7413b5e55e831c350831271e8b1391"
+  integrity sha512-SZ78Gwpkp3EUhjBIp0lSojeQ35V9acF8SubJsMeOH/vlOUE40GOnvvwWZnF05lO7bIB0dOHhhJy4N7IIAWxP2w==
   dependencies:
-    "@editorjs/helpers" "0.0.5"
+    "@editorjs/helpers" "^0.0.4"
 
 "@editorjs/editorjs@^2.29.1":
   version "2.30.5"
   resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.30.5.tgz#c1a6fc2b99f567a0271408c0edd51d3da21b4534"
   integrity sha512-sE7m/UPbuf+nSGjv9cmWggFsfvtYlgEX7PCby2lZWvOsOLbRxuLT+ZYlwbWshD+8BFJwiAmBj9e+ScZcOjCzeg==
 
-"@editorjs/helpers@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@editorjs/helpers/-/helpers-0.0.5.tgz#db93402027c12eb4750b9e5ae7752249b1c7c703"
-  integrity sha512-9xP+/Ai4NR+bBPKDt6jYnhkYs8OUDGGIMUKikyck8yiJV35/vpZ7WkowOy5sCZcyu7+lI5bkFXNoDn5jes0diA==
+"@editorjs/helpers@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@editorjs/helpers/-/helpers-0.0.4.tgz#9351373f609e9f8333e0421f7b396c7c7fd41bfa"
+  integrity sha512-ieg3dzo2m1/ELze/RMNADiAiC5amXxIlVXoJ5vvXITOu/p/dPsrF+Oi3h5gBYvtGk9vg5LJUSG5YWU0tBUO1tw==
 
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,22 +33,22 @@
   resolved "https://registry.yarnpkg.com/@codexteam/icons/-/icons-0.3.2.tgz#b7aed0ba7b344e07953101f5476cded570d4f150"
   integrity sha512-P1ep2fHoy0tv4wx85eic+uee5plDnZQ1Qa6gDfv7eHPkCXorMtVqJhzMb75o1izogh6G7380PqmFDXV3bW3Pig==
 
-"@editorjs/dom@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@editorjs/dom/-/dom-0.0.1.tgz#62297e0b597509598d4829aeaeb4b6a8a59a5d03"
-  integrity sha512-cFTVjsCKUFZHDjG9jFeooqkMchlWjkNbIJjWUYEA4DeK8VOc6VYiW3GJCjw4J2BXSkzwm3T4O7r6ra2dZxTx2w==
+"@editorjs/dom@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@editorjs/dom/-/dom-0.0.6.tgz#b35a6b4204305f3b1bc3eb7b4c4dec21a4070e3d"
+  integrity sha512-bPwkRV2O7mTB7XoGpf0/anSAOENbwXu2EcOT1M3/lvM9XJ7YfvOgyeSmEZRqUyw5RYBr94yc2fQw++vHMINeqA==
   dependencies:
-    "@editorjs/helpers" "workspace:*"
+    "@editorjs/helpers" "0.0.5"
 
 "@editorjs/editorjs@^2.29.1":
   version "2.30.5"
   resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.30.5.tgz#c1a6fc2b99f567a0271408c0edd51d3da21b4534"
   integrity sha512-sE7m/UPbuf+nSGjv9cmWggFsfvtYlgEX7PCby2lZWvOsOLbRxuLT+ZYlwbWshD+8BFJwiAmBj9e+ScZcOjCzeg==
 
-"@editorjs/helpers@workspace:*":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@editorjs/helpers/-/helpers-0.0.1.tgz#580eadca9b3a646d7466434579cee90ebebdc0a8"
-  integrity sha512-oEp8pqqvvx1Yut4KyvEoYKroAe5TFRNdXOPGIerleIB/6HA/n5hvARa8HRNQtOlMJH40vcRTT3Z+74J3NjlQlQ==
+"@editorjs/helpers@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@editorjs/helpers/-/helpers-0.0.5.tgz#db93402027c12eb4750b9e5ae7752249b1c7c703"
+  integrity sha512-9xP+/Ai4NR+bBPKDt6jYnhkYs8OUDGGIMUKikyck8yiJV35/vpZ7WkowOy5sCZcyu7+lI5bkFXNoDn5jes0diA==
 
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"


### PR DESCRIPTION
Issue appered because of incorrect usage of yarn workspaces of the `@editorjs/dom` module
[This](https://github.com/editor-js/utils/issues/16) issue is related 
Solved since `@editorjs/dom` 0.0.5

fixes #68 