### PR TITLE
Fix type mismatch and version discrepancy in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "email": "team@codex.so"
   },
   "devDependencies": {
-    "@editorjs/editorjs": "^2.29.1",
+    "@editorjs/editorjs": "^2.30.7",
     "typescript": "^5.4.5",
     "vite": "^4.5.0",
     "vite-plugin-css-injected-by-js": "^3.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,17 +19,17 @@ export interface QuoteConfig extends ToolConfig {
   /**
    * Placeholder text to display in the quote's text input.
    */
-  quotePlaceholder: string;
+  quotePlaceholder?: string;
 
   /**
    * Placeholder text to display in the quote's caption input.
    */
-  captionPlaceholder: string;
+  captionPlaceholder?: string;
 
   /**
    * Default alignment for the quote.
    */
-  defaultAlignment: Alignment;
+  defaultAlignment?: Alignment;
 }
 
 /**
@@ -73,7 +73,7 @@ interface QuoteParams {
   /**
    * Quote tool configuration
    */
-  config: QuoteConfig;
+  config?: QuoteConfig;
   /**
    * Editor.js API
    */
@@ -180,9 +180,9 @@ export default class Quote implements BlockTool {
     this.readOnly = readOnly;
 
     this._quotePlaceholder =
-      config.quotePlaceholder || Quote.DEFAULT_QUOTE_PLACEHOLDER;
+      config?.quotePlaceholder || Quote.DEFAULT_QUOTE_PLACEHOLDER;
     this._captionPlaceholder =
-      config.captionPlaceholder || Quote.DEFAULT_CAPTION_PLACEHOLDER;
+      config?.captionPlaceholder || Quote.DEFAULT_CAPTION_PLACEHOLDER;
 
     this._data = {
       text: data.text || "",
@@ -190,7 +190,7 @@ export default class Quote implements BlockTool {
       alignment:
         (Object.values(Alignment).includes(data.alignment as Alignment) &&
           data.alignment) ||
-        config.defaultAlignment ||
+        config?.defaultAlignment ||
         DEFAULT_ALIGNMENT,
     };
     this._CSS = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
   dependencies:
     "@editorjs/helpers" "^0.0.4"
 
-"@editorjs/editorjs@^2.29.1":
-  version "2.30.5"
-  resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.30.5.tgz#c1a6fc2b99f567a0271408c0edd51d3da21b4534"
-  integrity sha512-sE7m/UPbuf+nSGjv9cmWggFsfvtYlgEX7PCby2lZWvOsOLbRxuLT+ZYlwbWshD+8BFJwiAmBj9e+ScZcOjCzeg==
+"@editorjs/editorjs@^2.30.7":
+  version "2.30.7"
+  resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.30.7.tgz#6ba210490c1040c55ef7e5ef040c4c6e3dc722e7"
+  integrity sha512-FfdeUqrgcKWC+Cy2GW6Dxup6s2TaRKokR4FL+HKXshu6h9Y//rrx4SQkURgkZOCSbV77t9btbmAXdFXWGB+diw==
 
 "@editorjs/helpers@^0.0.4":
   version "0.0.4"


### PR DESCRIPTION
Fixed the type mismatch error where QuoteParams was expected but BlockToolConstructorOptions<any, any> was passed. Additionally, resolved the version discrepancy between package.json and the lockfile for @editorjs/editorjs, ensuring the versions are consistent.